### PR TITLE
To solve the conflict with TSM

### DIFF
--- a/KkthnxUI/Modules/Miscellaneous/Elements/AlreadyKnown.lua
+++ b/KkthnxUI/Modules/Miscellaneous/Elements/AlreadyKnown.lua
@@ -147,7 +147,7 @@ hooksecurefunc("MerchantFrame_UpdateBuybackInfo", Hook_UpdateBuybackInfo)
 local function Hook_UpdateAuctionHouse(self)
 	local numResults = self.getNumEntries()
 	local buttons = HybridScrollFrame_GetButtons(self.ScrollFrame)
-	local buttonCount = #buttons
+	local buttonCount = buttons and #buttons or 0
 	local offset = self:GetScrollOffset()
 	for i = 1, buttonCount do
 		local visible = i + offset <= numResults


### PR DESCRIPTION
TradeSkillMaster replaces default UI with its own window when purchasing stuffs from AH and NPC, which causes nil error with "buttons" sometimes

Issue Fixed #
